### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,14 @@ Notable features:
 Pricing [here](https://www.ubicloud.com/docs/github-actions-integration/price-performance).
 
 Notable features:
-- **By far one of the cheapest providers** at about ~10x cheaper than official GH Actions runners.[^ubicloud-cheap].
+- **1-line change to get faster and cheaper builds in most projects.**[^ubicloud-cheap]
+- **By far one of the cheapest providers** at about ~10x cheaper than official GH Actions runners.[^ubicloud-cheap]
 - **1250 free minutes per month.**[^5a]
-- Unclear hardware specs. ⚠️
+- Source open under the Elastic V2 license, if you choose to manage Ubicloud VMs yourself[^5b]
 
 [^ubicloud-cheap]: https://www.ubicloud.com/docs/github-actions-integration/price-performance
 [^5a]: https://www.ubicloud.com/use-cases/github-actions
+[^5b]: https://github.com/ubicloud/ubicloud/blob/main/routes/web/webhook/github.rb
 
 ### GitRunners
 


### PR DESCRIPTION
* Added new bullet points on "1-line change for cheaper and faster builds" and the GitHub Actions integration being open under Elastic V2 license

* Removed bullet point on undocumented hardware. We reference our bare metal provider in https://www.ubicloud.com/docs/quick-start/managed-services and https://www.ubicloud.com/docs/about/pricing (same provider as Hetzner)

I could reference the underlying bare metal provider in the readme. However, our customers then ask about our virtualization technology and that would requires another reference.