### PR TITLE
Ubicloud Licence information change

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Notable features:
 - **By far one of the cheapest providers** at about ~10x cheaper than official GH Actions runners.[^ubicloud-cheap]
 - **1250 free minutes per month.**[^5a]
 - Native ARM support.[^5b]
-- Source open under the Elastic V2 license, if you choose to manage Ubicloud VMs yourself[^5c]
+- Open source under the GNU AGPL v3.0 license.[^5c]
 
 [^ubicloud-cheap]: https://www.ubicloud.com/docs/github-actions-integration/price-performance
 [^5a]: https://www.ubicloud.com/use-cases/github-actions


### PR DESCRIPTION
Ubicloud has changed its licence from Elastic V2 to GNU Affero General Public License v3.0. This commit updates that information.